### PR TITLE
Set retain_collection_types to True

### DIFF
--- a/pydra/tasks/nipype1/tests/test_nipype1task.py
+++ b/pydra/tasks/nipype1/tests/test_nipype1task.py
@@ -26,23 +26,16 @@ def test_isolation(tmp_path):
 
 
 def test_preserve_input_types():
-
-    def with_tuple(in_param : tuple):
-        out_param = in_param 
+    def with_tuple(in_param: tuple):
+        out_param = in_param
         return out_param
 
-
     tuple_interface = nutil.Function(
-        input_names = ['in_param'],
-        output_names = ['out_param'],
-        function = with_tuple
+        input_names=["in_param"], output_names=["out_param"], function=with_tuple
     )
 
-    nipype1_task_tuple = Nipype1Task(
-        interface = tuple_interface,
-        in_param = tuple(['test'])
-    )
-    
+    nipype1_task_tuple = Nipype1Task(interface=tuple_interface, in_param=tuple(["test"]))
+
     nipype1_task_tuple()
 
-    assert(isinstance(nipype1_task_tuple._interface._list_outputs()['out_param'], tuple))
+    assert isinstance(nipype1_task_tuple._interface._list_outputs()["out_param"], tuple)

--- a/pydra/tasks/nipype1/tests/test_nipype1task.py
+++ b/pydra/tasks/nipype1/tests/test_nipype1task.py
@@ -3,6 +3,8 @@ import shutil
 from pkg_resources import resource_filename
 
 from nipype.interfaces import fsl
+import nipype.interfaces.utility as nutil
+
 from pydra.tasks.nipype1.utils import Nipype1Task
 
 
@@ -21,3 +23,26 @@ def test_isolation(tmp_path):
     res = slicer()
     assert res.output.out_files
     assert all(fname.startswith(str(out_dir)) for fname in res.output.out_files)
+
+
+def test_preserve_input_types():
+
+    def with_tuple(in_param : tuple):
+        out_param = in_param 
+        return out_param
+
+
+    tuple_interface = nutil.Function(
+        input_names = ['in_param'],
+        output_names = ['out_param'],
+        function = with_tuple
+    )
+
+    nipype1_task_tuple = Nipype1Task(
+        interface = tuple_interface,
+        in_param = tuple(['test'])
+    )
+    
+    nipype1_task_tuple()
+
+    assert(isinstance(nipype1_task_tuple._interface._list_outputs()['out_param'], tuple))

--- a/pydra/tasks/nipype1/utils.py
+++ b/pydra/tasks/nipype1/utils.py
@@ -67,7 +67,9 @@ class Nipype1Task(pydra.engine.task.TaskBase):
         self.output_spec = traitedspec_to_specinfo(interface._outputs())
 
     def _run_task(self):
-        inputs = attr.asdict(self.inputs, filter=lambda a, v: v is not attr.NOTHING, retain_collection_types=True)
+        inputs = attr.asdict(
+            self.inputs, filter=lambda a, v: v is not attr.NOTHING, retain_collection_types=True
+        )
         node = nipype.Node(self._interface, base_dir=self.output_dir, name=self.name)
         node.inputs.trait_set(**inputs)
         res = node.run()

--- a/pydra/tasks/nipype1/utils.py
+++ b/pydra/tasks/nipype1/utils.py
@@ -67,7 +67,7 @@ class Nipype1Task(pydra.engine.task.TaskBase):
         self.output_spec = traitedspec_to_specinfo(interface._outputs())
 
     def _run_task(self):
-        inputs = attr.asdict(self.inputs, filter=lambda a, v: v is not attr.NOTHING)
+        inputs = attr.asdict(self.inputs, filter=lambda a, v: v is not attr.NOTHING, retain_collection_types=True)
         node = nipype.Node(self._interface, base_dir=self.output_dir, name=self.name)
         node.inputs.trait_set(**inputs)
         res = node.run()


### PR DESCRIPTION
This prevents `attrs.asdict()` to change the type of the inputs from `set` or `tuple` to `list`. The default behavior is problematic in the case of `spmSegmentation` for example where the input `tissues` has to be a `tuple` of `tuples`