### PR TITLE
ENH: Use attrs namespace

### DIFF
--- a/pydra/tasks/nipype1/utils.py
+++ b/pydra/tasks/nipype1/utils.py
@@ -1,6 +1,6 @@
 import pydra
 import nipype
-import attr
+import attrs
 import typing as ty
 
 
@@ -9,7 +9,7 @@ def traitedspec_to_specinfo(traitedspec):
     return pydra.specs.SpecInfo(
         name="Inputs",
         fields=[
-            (name, attr.ib(type=ty.Any, metadata={"help_string": trait.desc}))
+            (name, attrs.field(metadata={"help_string": trait.desc}))
             for name, trait in traitedspec.traits().items()
             if name in trait_names
         ],
@@ -67,9 +67,7 @@ class Nipype1Task(pydra.engine.task.TaskBase):
         self.output_spec = traitedspec_to_specinfo(interface._outputs())
 
     def _run_task(self):
-        inputs = attr.asdict(
-            self.inputs, filter=lambda a, v: v is not attr.NOTHING, retain_collection_types=True
-        )
+        inputs = attrs.asdict(self.inputs, filter=lambda a, v: v is not attrs.NOTHING)
         node = nipype.Node(self._interface, base_dir=self.output_dir, name=self.name)
         node.inputs.trait_set(**inputs)
         res = node.run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ python_requires = >=3.7
 install_requires =
     pydra >= 0.6.2
     nipype
+    attrs >= 21.3.0
 packages = find_namespace:
 
 [options.packages.find]


### PR DESCRIPTION
The `attrs` namespace is now preferred over the old `attr`. It has been introduced since version `21.3.0`, hence the necessary minimum version specified in the package metadata.